### PR TITLE
Date header can't be removed anymore

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "symfony/http-foundation": "^2.7 || ^3.0"
     },
     "require-dev": {
+        "guzzlehttp/psr7": "^1.0",
         "phpunit/phpunit": "^5.7.7 || ^6.0",
         "pimple/pimple": "^3.0",
         "silex/silex": "^2.0",

--- a/test/ApiProblemHandlerTest.php
+++ b/test/ApiProblemHandlerTest.php
@@ -19,13 +19,12 @@ final class ApiProblemHandlerTest extends TestCase
         $handler = new ApiProblemHandler();
 
         $response = $handler->handle($apiProblem);
-        $response->headers->remove('Date');
 
         $this->assertSame($expectedStatus, $response->getStatusCode());
         $this->assertSame([
             'cache-control' => ['no-cache, private'],
             'content-type' => ['application/problem+json'],
-        ], $response->headers->all());
+        ], $this->removeDate($response->headers->all()));
         $this->assertJsonStringEqualsJsonString(json_encode($expected), $response->getContent());
     }
 
@@ -68,5 +67,12 @@ final class ApiProblemHandlerTest extends TestCase
                 'foo' => 'bar',
             ],
         ];
+    }
+
+    private function removeDate(array $headers)
+    {
+        unset($headers['date']);
+
+        return $headers;
     }
 }


### PR DESCRIPTION
See https://github.com/symfony/http-foundation/blob/master/ResponseHeaderBag.php#L39-L42 which imposes this on users