### PR TITLE
symfony/http-foundation security bump

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^7.0",
         "crell/api-problem": "^2.0",
-        "symfony/http-foundation": "~2.8.35 || ~3.4.35"
+        "symfony/http-foundation": "^2.8.35 || ^3.4.35"
     },
     "require-dev": {
         "guzzlehttp/psr7": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^7.0",
         "crell/api-problem": "^2.0",
-        "symfony/http-foundation": "^2.7 || ^3.0"
+        "symfony/http-foundation": "~2.8.35 || ~3.4.35"
     },
     "require-dev": {
         "guzzlehttp/psr7": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^7.0",
         "crell/api-problem": "^2.0",
-        "symfony/http-foundation": "^2.8.35 || ^3.4.35"
+        "symfony/http-foundation": "^2.8.52 || ^3.4.35"
     },
     "require-dev": {
         "guzzlehttp/psr7": "^1.0",


### PR DESCRIPTION
I don't know if this is a result of @giorgiosironi 's work yesterday to get the Alfred elife-libraries build to work, but this fixes the version of symfony/http-foundation 

see https://getcomposer.org/doc/articles/versions.md#caret-version-range-

Not sure if github understands the more sophisticated composer dependency logic though..